### PR TITLE
Generalizing start DFA

### DIFF
--- a/.github/workflows/python-linter.yaml
+++ b/.github/workflows/python-linter.yaml
@@ -39,10 +39,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-linter.yaml
+++ b/.github/workflows/python-linter.yaml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/jobmanager/psi4_utils/psi4_utils.py
+++ b/jobmanager/psi4_utils/psi4_utils.py
@@ -278,7 +278,7 @@ class Psi4Utils:
             if "_hfx_" in base_func:
                 #if hfx in functional, expects in the form functional_hfx_XX, where XX is the percent of HFX included.
                 func = base_func.split('_')[0]
-                hfx = base_func.split('_')[-1]
+                hfx = int(base_func.split('_')[-1])
                 e, wfn = psi4.energy("scf", dft_functional=self.get_hfx_functional(func, hfx),  molecule=mol, return_wfn=True)
             else:
                 e, wfn = psi4.energy(base_func, molecule=mol, return_wfn=True)
@@ -346,7 +346,7 @@ class Psi4Utils:
             if "_hfx_" in base_func:
                 #if hfx in functional, expects in the form functional_hfx_XX, where XX is the percent of HFX included.
                 func = base_func.split('_')[0]
-                hfx = base_func.split('_')[-1]
+                hfx = int(base_func.split('_')[-1])
                 e, wfn = psi4.energy("scf", dft_functional=self.get_hfx_functional(func, hfx),  molecule=mol, return_wfn=True)
             else:
                 e, wfn = psi4.energy(base_func, molecule=mol, return_wfn=True)
@@ -378,7 +378,7 @@ class Psi4Utils:
                 if "_hfx_" in base_func:
                     #if hfx in functional, expects in the form functional_hfx_XX, where XX is the percent of HFX included.
                     func = base_func.split('_')[0]
-                    hfx = base_func.split('_')[-1]
+                    hfx = int(base_func.split('_')[-1])
                     e, wfn = psi4.energy("scf", dft_functional=self.get_hfx_functional(func, hfx),  molecule=mol, return_wfn=True)
                 else:
                     e, wfn = psi4.energy(base_func, molecule=mol, return_wfn=True)

--- a/jobmanager/psi4_utils/psi4_utils.py
+++ b/jobmanager/psi4_utils/psi4_utils.py
@@ -13,6 +13,18 @@ class Psi4Utils:
     """
 
     def __init__(self, psi4_config):
+        """
+        Stores the dictionary of options for the Psi4 workflow.
+        """
+
+        #define the base functional that other calculations will be started from
+        if "base_functional" not in psi4_config:
+            #defaults to B3LYP
+            psi4_config["base_functional"] = 'b3lyp'
+        else:
+            #remove parentheses from functional names
+            functional = psi4_config["base_functional"]
+            psi4_config["base_functional"] = functional.replace("(", "l-").replace(")", "-r")
         self.config = psi4_config
 
     def lacvps(self, mol, role):
@@ -201,23 +213,24 @@ class Psi4Utils:
         return hfx_func
 
 
-    def run_b3lyp(self, rundir="./", return_wfn=True,
+    def run_initial(self, rundir="./", return_wfn=True,
                   psi4_scr = './', filename='output'):
         """
-        Runs a Psi4 single point calculation using B3LYP in Psi4, from a TC molden.
+        Runs a Psi4 single point calculation in Psi4, starting from a TC molden.
+        Will use the functional in psi4_config['base_functional'] if provided, otherwise B3LYP.
 
         Will write three files:
         -wfn-1step.180.npy: wfn file for a 1-step SCF, used only to get a wfn object.
-        -wfn-1step-tc.180.npy: wfn file populated with the coefficients from the molden
+        -wfn-1step-tc.180.npy: wfn file populated with the coefficients from the TC molden.
         -wfn.180.npy: wfn file that has been converged in Psi4 with the requested parameters,
         starting from the TC initial guess.
 
-        Results will be stored in rundir/b3lyp.
+        Results will be stored in 'rundir/' + psi4_config['base_functional'] .
 
         Parameters:
             rundir: str
-                Path where the B3LYP calculation will be run from.
-                Results and wavefunctions will be stored in a subdirectory named b3lyp.
+                Path where the calculation will be run from.
+                Results and wavefunctions will be stored in a subdirectory with the name in psi4_config['base_functional'].
             return_wfn: bool
                 Whether or not the wfn file should be written after the calculation.
             psi4_scr: str
@@ -226,6 +239,7 @@ class Psi4Utils:
                 Name out the output .dat file containing results.
         """
         psi4_config = self.config
+        base_func = psi4_config['base_functional']
         #update the Psi4 config with the charge, spin, and method
         #in the charge_spin_info json file.
         with open(psi4_config["charge-spin-info"], "r") as f:
@@ -233,14 +247,14 @@ class Psi4Utils:
         psi4_config.update(d)
         #Ensure that the run directory exists
         run_utils = RunUtils()
-        run_utils.ensure_dir(rundir + 'b3lyp')
+        run_utils.ensure_dir(rundir + base_func)
         #set up the molecule and calculation parameters
         sym = 'c1' if 'sym' not in psi4_config else psi4_config['sym']
         mol = self.get_molecule(psi4_config["xyzfile"], psi4_config["charge"], psi4_config["spin"], sym)
         self.setup_dft_parameters()
         if os.path.isfile(psi4_config["moldenfile"]):
             #logic to transfer the TC coefficients to Psi4
-            psi4.core.set_output_file(rundir + 'b3lyp/' + filename + '.dat', False)
+            psi4.core.set_output_file(rundir + base_func + '/' + filename + '.dat', False)
             # 1-step SCF
             #run very crudely, only goal is to get the wfn object, will later populate with the molden results
             psi4.set_options({
@@ -251,6 +265,8 @@ class Psi4Utils:
             #If def2-TZVP, converge in def2-SV(P) first, since expecting to project up from def2-SV(P)
             if psi4_config["basis"] == "def2-tzvp":
                 psi4.set_options({"basis": "def2-sv(p)"})
+            '''
+            #Deprecated from when only B3LYP was supported as a base functional, updated to now include other functionals
             #If the initial calculation was done with B3LYP and a HFX not equal to 20, use functional defined in get_hfx_functional
             if "b3lyp_hfx" in psi4_config and psi4_config["b3lyp_hfx"] != 20:
                 print("customized b3lyp with different HFX: ", psi4_config["b3lyp_hfx"])
@@ -258,6 +274,15 @@ class Psi4Utils:
             else:
                 e, wfn = psi4.energy('b3lyp', molecule=mol, return_wfn=True)
             wfn.to_file(rundir + "b3lyp/wfn-1step.180")
+            '''
+            if "_hfx_" in base_func:
+                #if hfx in functional, expects in the form functional_hfx_XX, where XX is the percent of HFX included.
+                func = base_func.split('_')[0]
+                hfx = base_func.split('_')[-1]
+                e, wfn = psi4.energy("scf", dft_functional=self.get_hfx_functional(func, hfx),  molecule=mol, return_wfn=True)
+            else:
+                e, wfn = psi4.energy(base_func, molecule=mol, return_wfn=True)
+            wfn.to_file(rundir + base_func + "/wfn-1step.180")
             # Get converged WFN
             d_molden = load_molden(psi4_config["moldenfile"])
             #if calculation restricted or not, checking for rks or rhf references
@@ -274,18 +299,18 @@ class Psi4Utils:
             else:
                 raise ValueError('Unsuppoorted Basis Set encountered! Please use 6-31G, LACVP*, or def2 basis sets.')
             #populate the 1-step SCF wfn with the coefficients from the molden
-            wfn_minimal_np = np.load(rundir + "b3lyp/wfn-1step.180.npy", allow_pickle=True)
+            wfn_minimal_np = np.load(rundir + base_func + "/wfn-1step.180.npy", allow_pickle=True)
             wfn_minimal_np[()]['matrix']["Ca"] = Ca
             if not restricted:
                 wfn_minimal_np[()]['matrix']["Cb"] = Cb
             else:
                 wfn_minimal_np[()]['matrix']["Cb"] = Ca
-            np.save(rundir + "b3lyp/wfn-1step-tc.180.npy", wfn_minimal_np)
+            np.save(rundir + base_func + "/wfn-1step-tc.180.npy", wfn_minimal_np)
             # Copy wfn file to the right place with a right name
             #Psi4 requires format /scratch/output.moleculename.pid.180.npy
             pid = str(os.getpid())
             targetfile = psi4_scr + filename + '.default.' + pid + '.180.npy'
-            shutil.copyfile(rundir + "b3lyp/wfn-1step-tc.180.npy", targetfile)
+            shutil.copyfile(rundir + base_func + "/wfn-1step-tc.180.npy", targetfile)
             # Final scf---
             #only allow for 50 iterations since the initial guess should converge quickly
             psi4.set_options({
@@ -295,7 +320,7 @@ class Psi4Utils:
                 "fail_on_maxiter": True})
         else:
             #if no molden provided, allow for more iterations to ensure convergence
-            psi4.core.set_output_file(rundir + 'b3lyp/' + filename + '.dat', False)
+            psi4.core.set_output_file(rundir + base_func + '/' + filename + '.dat', False)
             print("Warning: no Molden file is used to initialize this calculation!")
             psi4.set_options({
                 "maxiter": 250 if "maxiter" not in psi4_config else psi4_config["maxiter"],
@@ -305,9 +330,11 @@ class Psi4Utils:
                 "fail_on_maxiter": True})
             if psi4_config["basis"] == "def2-tzvp":
                 psi4.set_options({"basis": "def2-sv(p)"})
-        sucess = False
+        success = False
         try:
             #final SCF calculation
+            '''
+            #Deprecated, see above deprecated section
             if "b3lyp_hfx" in psi4_config and psi4_config["b3lyp_hfx"] != 20:
                 #if calculation was done with a HFX different from 20, use custom B3LYP
                 print("customized b3lyp with different HFX: ", psi4_config["b3lyp_hfx"])
@@ -315,31 +342,51 @@ class Psi4Utils:
             else:
                 e, wfn = psi4.energy('b3lyp', molecule=mol, return_wfn=True)
             wfn.to_file(rundir + "b3lyp/wfn.180")
-            sucess = True
+            '''
+            if "_hfx_" in base_func:
+                #if hfx in functional, expects in the form functional_hfx_XX, where XX is the percent of HFX included.
+                func = base_func.split('_')[0]
+                hfx = base_func.split('_')[-1]
+                e, wfn = psi4.energy("scf", dft_functional=self.get_hfx_functional(func, hfx),  molecule=mol, return_wfn=True)
+            else:
+                e, wfn = psi4.energy(base_func, molecule=mol, return_wfn=True)
+            wfn.to_file(rundir + base_func + "/wfn.180")
+            success = True
         except:
             print("This calculation does not converge.")
         #If using def2-TZVP, did the first calculation in def2-SV(P), so do another calculation to get TZVP.
-        if psi4_config["basis"] == "def2-tzvp" and sucess:
+        if psi4_config["basis"] == "def2-tzvp" and success:
             #Project to def2-TZVP; allow for more iterations since doing a projection
             
             #copy the result of the def2-SV(P) calculation to Psi4's expected location
             #check if this is redundant, i.e., if Psi4 saves the wfn of the last calculation to the default location
             pid = str(os.getpid())
             targetfile = psi4_scr + filename + '.default.' + pid + '.180.npy'
-            shutil.copyfile(rundir + "b3lyp/wfn.180.npy", targetfile)
+            shutil.copyfile(rundir + base_func + "/wfn.180.npy", targetfile)
 
             psi4.set_options({"basis": "def2-tzvp", "maxiter": 200 if "maxiter" not in psi4_config else psi4_config["maxiter"]})
             try:
+                '''
+                #Deprecated, see above
                 if "b3lyp_hfx" in psi4_config and psi4_config["b3lyp_hfx"] != 20:
                     print("customized b3lyp with different HFX: ", psi4_config["b3lyp_hfx"])
                     e, wfn = psi4.energy("scf", self.get_hfx_functional('b3lyp', psi4_config["b3lyp_hfx"]),  molecule=mol, return_wfn=True)
                 else:
                     e, wfn = psi4.energy('b3lyp', molecule=mol, return_wfn=True)
                 wfn.to_file(rundir + "b3lyp/wfn.180")
+                '''
+                if "_hfx_" in base_func:
+                    #if hfx in functional, expects in the form functional_hfx_XX, where XX is the percent of HFX included.
+                    func = base_func.split('_')[0]
+                    hfx = base_func.split('_')[-1]
+                    e, wfn = psi4.energy("scf", dft_functional=self.get_hfx_functional(func, hfx),  molecule=mol, return_wfn=True)
+                else:
+                    e, wfn = psi4.energy(base_func, molecule=mol, return_wfn=True)
+                wfn.to_file(rundir + base_func + "/wfn.180")
             except:
                 print("This calculation does not converge.")
-        #Check if the B3LYP calculation succeeded
-        success = run_utils.check_sucess(path=rundir + 'b3lyp')
+        #Check if the calculation succeeded
+        success = run_utils.check_success(path=rundir + base_func)
         #remove copied wfn file, psi4 log files
         for filename in os.listdir('./'):
             if ("psi." in filename) or ("default" in filename):
@@ -434,7 +481,7 @@ class Psi4Utils:
             if return_wfn:
                 wfn.to_file(rundir + "/wfn.180")
         #Check success, Remove temporary files
-        success = run_utils.check_sucess(path=rundir)
+        success = run_utils.check_success(path=rundir)
         for filename in os.listdir("./"):
             if ("psi." in filename) or ("default" in filename):
                 print("removing: :", filename)
@@ -500,7 +547,7 @@ class Psi4Utils:
             # os.remove(wfn)
         except:
             print("This calculation does not converge.")
-        success = run_utils.check_sucess(path=rundir)
+        success = run_utils.check_success(path=rundir)
         #remove temporary files
         for filename in os.listdir("./"):
             if ("psi." in filename) or ("default" in filename):
@@ -514,9 +561,12 @@ class Psi4Utils:
         Will run a psi4 calculation using the method specified in method, using the
         functional specified in functional.
 
+        Note: if using run_initial, will ignore the functional argument, and instead use
+        whatever is specified in psi4_config['base_functional'], or b3lyp if not specified.
+
         Parameters:
             method: str
-                Either run_b3lyp or run_general, depending on what calculation is being run.
+                Either run_initial or run_general, depending on what calculation is being run.
             functional: str
                 Name of the functional one wants to use in the calculation.
             rundir: str
@@ -539,24 +589,27 @@ class Psi4Utils:
                 Whether or not the calculation was successful.
         """
 
-        if method == 'run_b3lyp' and functional != 'b3lyp':
-            raise NotImplementedError('Method run_b3lyp can only be used with functional b3lyp.')
+        psi4_config = self.config
+        base_func = psi4_config['base_functional']
 
-        if method == 'run_b3lyp':
-            runfunc = self.run_b3lyp
+        if method == 'run_initial':
+            print(f'Running initial calculation with base functional {base_func}.')
+            functional = base_func
+            #raise NotImplementedError('Method run_initial can only be used with the base functional specified in the config file.')
+
+        if method == 'run_initial':
+            runfunc = self.run_initial
         elif method == 'run_general':
             runfunc = self.run_general
         else:
             raise NotImplementedError("Please specify a valid method.")
 
-        psi4_config = self.config
-
         print(f"==={functional}===")
         #Clean name to prevent forbidden characters
         functional = functional.replace("(", "l-").replace(")", "-r")
-        #If the corresponding folder not present, run function from molden/b3lyp reference
+        #If the corresponding folder not present, run the calculation with the functions above
         if not os.path.isdir(functional):
-            if functional == 'b3lyp':
+            if functional == base_func:
                 success = runfunc(rundir=rundir, return_wfn=return_wfn,
                                   psi4_scr=psi4_scr, filename=filename)
             else:
@@ -578,7 +631,7 @@ class Psi4Utils:
                     resubed = True
             if resubed:
                 print("previous errored out. resubmitting...")
-                if functional == 'b3lyp':
+                if functional == base_func:
                     success = runfunc(rundir=rundir, return_wfn=return_wfn,
                                       psi4_scr=psi4_scr, filename=filename)
                 else:
@@ -595,7 +648,7 @@ class Psi4Utils:
                     success = True
                 else: #Did not converge in the given number of SCF iterations
                     if retry_scf:
-                        if functional == 'b3lyp':
+                        if functional == base_func:
                             success = runfunc(rundir=rundir, return_wfn=return_wfn,
                                               psi4_scr=psi4_scr, filename=filename)
                         else:

--- a/jobmanager/psi4_utils/psi4_utils.py
+++ b/jobmanager/psi4_utils/psi4_utils.py
@@ -357,7 +357,7 @@ class Psi4Utils:
         #If using def2-TZVP, did the first calculation in def2-SV(P), so do another calculation to get TZVP.
         if psi4_config["basis"] == "def2-tzvp" and success:
             #Project to def2-TZVP; allow for more iterations since doing a projection
-            
+
             #copy the result of the def2-SV(P) calculation to Psi4's expected location
             #check if this is redundant, i.e., if Psi4 saves the wfn of the last calculation to the default location
             pid = str(os.getpid())

--- a/jobmanager/psi4_utils/psi4_utils.py
+++ b/jobmanager/psi4_utils/psi4_utils.py
@@ -320,8 +320,14 @@ class Psi4Utils:
             print("This calculation does not converge.")
         #If using def2-TZVP, did the first calculation in def2-SV(P), so do another calculation to get TZVP.
         if psi4_config["basis"] == "def2-tzvp" and sucess:
-            #allow for more iterations since doing a projection
-            #TODO: seems to not use the converged sv(p) guess, write over the TC guess with the Psi4 result?
+            #Project to def2-TZVP; allow for more iterations since doing a projection
+            
+            #copy the result of the def2-SV(P) calculation to Psi4's expected location
+            #check if this is redundant, i.e., if Psi4 saves the wfn of the last calculation to the default location
+            pid = str(os.getpid())
+            targetfile = psi4_scr + filename + '.default.' + pid + '.180.npy'
+            shutil.copyfile(rundir + "b3lyp/wfn.180.npy", targetfile)
+
             psi4.set_options({"basis": "def2-tzvp", "maxiter": 200 if "maxiter" not in psi4_config else psi4_config["maxiter"]})
             try:
                 if "b3lyp_hfx" in psi4_config and psi4_config["b3lyp_hfx"] != 20:

--- a/jobmanager/psi4_utils/run_utils.py
+++ b/jobmanager/psi4_utils/run_utils.py
@@ -27,6 +27,10 @@ class RunUtils():
         Assumes it is being called in the same directory as the Psi4 output file,
         and that the output file is named output.dat.
 
+        TODO: This does not work for MP2 (and maybe other WFT methods),
+        the MP2 calculation is done after an SCF calculation and the second calculation
+        never prints "Computation Completed". Finding a workaround for this is needed.
+
         Parameters:
             path: str
                 Path where the calculation result is stored.
@@ -54,14 +58,18 @@ class RunUtils():
     def write_jobscript(self, psi4_config):
         """
         From a psi4_config JSON file, writes a jobscript for the appropriate cluster.
-        Memory should be specified in MB.
+        Memory should be specified in MB in the config file.
 
         Parameters:
-            psi4_config: str
-                Path to the psi4_config.json file containing job details.
+            psi4_config: dict
+                Dictionary containing the information in the loaded JSON.
         """
         if "cluster" not in psi4_config or psi4_config["cluster"] == "gibraltar":
             mem = int(psi4_config['memory'].split(" ")[0])/1000
+            if 'base_functional' in psi4_config:
+                base_func = psi4_config['base_functional'].replace("(", "l-").replace(")", "-r")
+            else:
+                base_func = 'b3lyp'
             with open("./jobscript.sh", "w") as fo:
                 fo.write("#$ -S /bin/bash\n")
                 fo.write("#$ -N psi4_dft\n")
@@ -119,7 +127,7 @@ class RunUtils():
 
                 if "trigger" in psi4_config:
                     fo.write("python -c 'from jobmanager.psi4_utils.run_scripts import RunScripts; RunScripts().loop_derivative_jobs()'  > $SGE_O_WORKDIR/deriv_nohup1.out 2> $SGE_O_WORKDIR/deriv_nohup1.err\n")
-                    fo.write("rm */*/psi.* */*/dfh.* */*-*/*.npy */b3lyp/*.molden */b3lyp/*1step*\n")
+                    fo.write("rm */*/psi.* */*/dfh.* */*-*/*.npy */" + base_func + "/*.molden */" + base_func + "/*1step*\n")
                 else:
                     fo.write("python -c 'from jobmanager.psi4_utils.run_scripts import RunScripts; RunScripts().loop_run()'  > $SGE_O_WORKDIR/nohup1.out 2> $SGE_O_WORKDIR/nohup1.err\n")
                     fo.write("python -c 'from jobmanager.psi4_utils.run_scripts import RunScripts; RunScripts().loop_run()'  > $SGE_O_WORKDIR/nohup2.out 2> $SGE_O_WORKDIR/nohup1.err\n")
@@ -129,7 +137,7 @@ class RunUtils():
                         fo.write("python -c 'from jobmanager.psi4_utils.run_scripts import RunScripts; RunScripts().loop_rescue()' > $SGE_O_WORKDIR/rescue_nohup1.out\n")
                         fo.write("python -c 'from jobmanager.psi4_utils.run_scripts import RunScripts; RunScripts().loop_rescue()' > $SGE_O_WORKDIR/rescue_nohup2.out\n")
                         fo.write("python -c 'from jobmanager.psi4_utils.run_scripts import RunScripts; RunScripts().loop_rescue()' > $SGE_O_WORKDIR/rescue_nohup3.out\n")
-                    fo.write("rm */psi.* */dfh.* *-*/*.npy b3lyp/*.molden b3lyp/*1step*\n")
+                    fo.write("rm */psi.* */dfh.* *-*/*.npy " + base_func + "/*.molden " + base_func + "/*1step*\n")
                 fo.write("cp -rf * $subdir\n")
         elif psi4_config["cluster"] == "expanse":
             mem = int(psi4_config['memory'].split(" ")[0])/psi4_config['num_threads']/1000

--- a/jobmanager/psi4_utils/run_utils.py
+++ b/jobmanager/psi4_utils/run_utils.py
@@ -21,7 +21,7 @@ class RunUtils():
         if not os.path.isdir(dirpath):
             os.makedirs(dirpath)
 
-    def check_sucess(self, path='./', output_name='output.dat'):
+    def check_success(self, path='./', output_name='output.dat'):
         """
         Checks if a Psi4 calculation is completed.
         Assumes it is being called in the same directory as the Psi4 output file,

--- a/jobmanager/psi4_utils/run_utils.py
+++ b/jobmanager/psi4_utils/run_utils.py
@@ -38,8 +38,14 @@ class RunUtils():
                 Whether or not the calculation succeeded.
         """
         success = False
+        #only look at the text from the latest computation
+        #Psi4 will call tstart() at the start of each computation
+        txt = ""
         with open(path + '/' + output_name, "r") as fo:
-            txt = "".join(fo.readlines())
+            for idx, line in enumerate(reversed(fo.readlines())):
+                txt += line
+                if 'tstart()' in line:
+                    break
         #Psi4 will write Computation Completed once the calculation finishes.
         if 'Computation Completed' in txt:
             success = True

--- a/psi4_guide.md
+++ b/psi4_guide.md
@@ -23,6 +23,10 @@ In the parent directory, one needs two files:
    - `bashrc`: The user's `.bashrc` file, used to help initialize the conda environment.
    - `conda_env`: The path to the `jobmanager` conda environment.
 
+Note that the workflow has been updated so that calculations can be initialized from an arbitrary functional, instead of just B3LYP. In order to use this functionality, add the keyword `base_functional` to the `.json` file outlined above and set it to the name of the functional to be used to initialize other calculations. Then, edit the path in `wfnfile` in the `.json` file to be whatever the name of your base functional is plus `/wfn.180.npy`. The workflow will work exactly the same as above, but now will initialize calculations from the set functional instead of b3lyp.
+
+Another functionality that has been added to this workflow is the HFX workflow. To use this, one adds the keyword `hfx_levels` to the `.json` file above, where the value is a list of integers that represent percentages of Hartree-Fock exchange to include. Then, for each functional specified in the `functional` list, they will be run at each of the HFX levels specified, starting from the nearest converged calculation.
+
 In each subdirectory, one needs three files:
  - A `.xyz` file, matching the naming convention established in the parent directory's `.json` file. This should give the geometry of the structure corresponding to the wavefunction in the `.molden` file, so either the geometry used in a single-point or the final frame of a geometry optimization.
  - A `.molden` file, matching the naming convention established in the parent directory's `.json` file. This should be the converged molden for the structure, calculated using B3LYP/LACVP* (or B3LYP/def2-SV(P)), which is found in the `/scr/` directory of a TeraChem calculation, by default.


### PR DESCRIPTION
Allows for the specification of the base functional, whose result is used to launch other calculations, in the Psi4 functionality. Was previously hardcoded to be B3LYP, but can now be specified to other functionals through the "base_functional" keyword in the config file.