### PR TITLE
reduced allowed time for supercloud psi4 calcs

### DIFF
--- a/jobmanager/psi4_utils/run_utils.py
+++ b/jobmanager/psi4_utils/run_utils.py
@@ -109,7 +109,7 @@ class RunUtils():
                 fo.write("#!/bin/bash\n")
                 fo.write(f"#SBATCH --job-name={jobname}\n")
                 fo.write("#SBATCH --nodes=1\n")
-                fo.write("#SBATCH --time=96:00:00\n")
+                fo.write("#SBATCH --time=24:00:00\n")
                 fo.write("#SBATCH --ntasks-per-node=%d\n" % psi4_config['num_threads'])
                 if "queue" in psi4_config and psi4_config["queue"] == "normal":
                     fo.write("#SBATCH --partition=normal\n")


### PR DESCRIPTION
Reducing allowed time from 96 to 24 hours to prevent few jobs which are failing to converge from acting as a bottleneck